### PR TITLE
Expose fields of the blocks

### DIFF
--- a/src/v6/scene_item/glyph_range.rs
+++ b/src/v6/scene_item/glyph_range.rs
@@ -2,10 +2,10 @@ use crate::{shared::pen_color::PenColor, v6::TypeParse, ParseError};
 
 #[derive(Debug, Clone)]
 struct Rectangle {
-    x: f64,
-    y: f64,
-    w: f64,
-    h: f64,
+    pub x: f64,
+    pub y: f64,
+    pub w: f64,
+    pub h: f64,
 }
 
 impl TypeParse for Rectangle {
@@ -23,11 +23,11 @@ impl TypeParse for Rectangle {
 
 #[derive(Debug, Clone)]
 pub struct GlyphRange {
-    start: u32,
-    length: u32,
-    text: String,
-    color: PenColor,
-    rectangles: Vec<Rectangle>,
+    pub start: u32,
+    pub length: u32,
+    pub text: String,
+    pub color: PenColor,
+    pub rectangles: Vec<Rectangle>,
 }
 
 impl TypeParse for GlyphRange {

--- a/src/v6/scene_item/glyph_range.rs
+++ b/src/v6/scene_item/glyph_range.rs
@@ -1,7 +1,7 @@
 use crate::{shared::pen_color::PenColor, v6::TypeParse, ParseError};
 
 #[derive(Debug, Clone)]
-struct Rectangle {
+pub struct Rectangle {
     pub x: f64,
     pub y: f64,
     pub w: f64,

--- a/src/v6/scene_item/line.rs
+++ b/src/v6/scene_item/line.rs
@@ -9,11 +9,11 @@ use crate::{
 
 #[derive(Debug, Clone)]
 pub struct Line {
-    color: PenColor,
-    tool: Tool,
-    points: Vec<Point>,
-    thickness_scale: f64,
-    starting_length: f32,
+    pub color: PenColor,
+    pub tool: Tool,
+    pub points: Vec<Point>,
+    pub thickness_scale: f64,
+    pub starting_length: f32,
 }
 
 pub fn point_serialize_size(version: u8) -> Result<u32, ParseError> {

--- a/src/v6/scene_item/point.rs
+++ b/src/v6/scene_item/point.rs
@@ -4,12 +4,12 @@ use crate::v6::block::BlockParse;
 
 #[derive(Debug, Clone)]
 pub struct Point {
-    x: f32,
-    y: f32,
-    speed: f32,
-    direction: f32,
-    width: f32,
-    pressure: f32,
+    pub x: f32,
+    pub y: f32,
+    pub speed: f32,
+    pub direction: f32,
+    pub width: f32,
+    pub pressure: f32,
 }
 
 impl BlockParse for Point {


### PR DESCRIPTION
Thank you for the nicely written parser, @Lyr-7D1h ! 

Currently, most of the blocks fields are not public and, accordingly, not accessible in the crates using them. Do you mind exposing them?